### PR TITLE
Programmatic enable/disable functionality for the OK button

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ var winMtds = L.control.window(map)
 | content()         | HTMLElement&#124;String  |  Gets window contet.        |
 | content(HTMLElement&#124;String)      | L.control.window object  |  Sets window content.        |
 | close()         | undefined  |  Hide and remove window.        |
+| enableBtn()         | undefined  |  Enables the OK button of the window (default).       |
+| disableBtn()         | undefined  |  Disables the OK button of the window.        |
 
 ### Other options
 | Property        | Description            | Default Value | Possible  values                                     |

--- a/src/L.Control.Window.css
+++ b/src/L.Control.Window.css
@@ -123,3 +123,7 @@
 .leaflet-control-window button:hover {
     opacity: 1;
 }
+.disabled{
+	opacity: .5;
+	pointer-events:none;
+}

--- a/src/L.Control.Window.js
+++ b/src/L.Control.Window.js
@@ -75,6 +75,14 @@ L.Control.Window = L.Control.extend({
 
         //map.on('resize',function(){self.mapResized()});
     },
+    disableBtn: function(){
+			this._btnOK.disabled=true;
+			this._btnOK.className='disabled';
+	},
+	enableBtn: function(){
+			this._btnOK.disabled=false;
+			this._btnOK.className='';
+	},
     title: function(titleContent){
         if (titleContent==undefined){
             return this.options.title
@@ -214,6 +222,8 @@ L.Control.Window = L.Control.extend({
         var btnOK= L.DomUtil.create('button','',this._containerPromptButtons);
         L.DomEvent.on(btnOK, 'click',this.promptCallback, this);
         btnOK.innerHTML=ok;
+        
+        this._btnOK=btnOK;
         
         var btnCancel= L.DomUtil.create('button','',this._containerPromptButtons);
         L.DomEvent.on(btnCancel, 'click', this.close, this);


### PR DESCRIPTION
two functions are added to allow the OK button to be programmatically enabled or disabled (e.g. testing on external conditions before showing the window).
